### PR TITLE
Use Nunito over Quicksand for headers

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,7 +7,7 @@
  */
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;1,100;1,300;1,400;1,500&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Quicksand&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito&display=swap');
 
 /* Default Infima variables here. See https://docusaurus.io/docs/styling-layout */
 :root {
@@ -39,7 +39,7 @@
   --ifm-color-accent: #545464;
   /* Define Infima font overrides */
   --ifm-font-family-base: 'Roboto', sans-serif;
-  --ifm-heading-font-family: 'Quicksand', sans-serif;
+  --ifm-heading-font-family: 'Nunito', sans-serif;
   --ifm-font-weight-base: 300;
   --ifm-heading-font-weight: 300;
   --ifm-button-font-weight: 400 !important;


### PR DESCRIPTION
# Updates to header font

## Description

Now using Nunito from Google fonts instead of Quicksand. It provides a cleaner sans serif option.