### PR TITLE
Add team page components

### DIFF
--- a/community/team.mdx
+++ b/community/team.mdx
@@ -4,6 +4,11 @@ title: Team
 slug: /team
 ---
 
+import {
+  ActiveTeamRow,
+  IndustryAdvisorRow,
+} from '@site/src/components/TeamProfileCards';
+
 :::caution
 
 Proceed with caution: This page is still under construction!
@@ -12,8 +17,7 @@ Proceed with caution: This page is still under construction!
 
 ## Active team
 
-- [Ari Dyckovsky](https://github.com/aridyckovsky)
-- [Peter Sokol-Hessner](https://github.com/psokolhessner)
+<ActiveTeamRow />
 
 ## Contributors
 
@@ -28,6 +32,9 @@ Coming soon...
 ### Industry
 
 Coming soon...
+
+<!-- Ucomment when descriptions read -->
+<!-- <IndustryAdvisorRow /> -->
 
 ## Acknowledgments
 

--- a/src/components/TeamProfileCards/index.js
+++ b/src/components/TeamProfileCards/index.js
@@ -1,0 +1,142 @@
+/**
+ * The following components are adapted from Facebook's TeamProfileCards component used in the official
+ * Docusaurus website.
+ *
+ * Link: https://github.com/facebook/docusaurus/blob/master/website/src/components/TeamProfileCards/index.js
+ */
+
+import React from 'react';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+function WebsiteLink({to, children}) {
+  return (
+    <Link to={to}>
+      {children || (
+        <Translate id="team.profile.websiteLinkLabel">website</Translate>
+      )}
+    </Link>
+  );
+}
+
+function TeamProfileCard({className, name, children, githubUrl, twitterUrl, linkedinUrl, photoUrl}) {
+  return (
+    <div className={className}>
+      <div className="card card--full-height">
+        <div className="card__header">
+          <div className="avatar avatar--vertical">
+            {/* GitHub URL returns photo when no photoUrl specified  */}
+            {(githubUrl && !photoUrl) && (
+              <img
+                className="avatar__photo avatar__photo--xl"
+                src={githubUrl + '.png'}
+                alt={`${name}'s avatar`}
+              />
+            )}
+            {/* Custom photo URL string  */}
+            {photoUrl && (
+              <img
+                className="avatar__photo avatar__photo--xl"
+                src={photoUrl}
+                alt={`${name}'s avatar`}
+              />
+            )}
+            <div className="avatar__intro">
+              <h3 className="avatar__name">{name}</h3>
+            </div>
+          </div>
+        </div>
+        <div className="card__body">{children}</div>
+        <div className="card__footer">
+          <div className="button-group button-group--block">
+            {githubUrl && (
+              <a className="button button--secondary" href={githubUrl}>
+                GitHub
+              </a>
+            )}
+            {twitterUrl && (
+              <a className="button button--secondary" href={twitterUrl}>
+                Twitter
+              </a>
+            )}
+            {linkedinUrl && (
+              <a className="button button--secondary" href={linkedinUrl}>
+                LinkedIn
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TeamProfileCardCol(props) {
+  return (
+    <TeamProfileCard {...props} className={'col col--6 margin-bottom--lg'} />
+  );
+}
+
+export function ActiveTeamRow() {
+  return (
+    <div className="row">
+      <TeamProfileCardCol
+        name="Ari Dyckovsky"
+        githubUrl="https://github.com/aridyckovsky"
+        twitterUrl="https://twitter.com/adyckovsky"
+        linkedinUrl="https://www.linkedin.com/in/aridyckovsky/">
+        <Translate id="team.profile.Ari Dyckovsky.body">
+          Start Your Lab's creator and core maintainer. Incoming doctoral
+          student at Princeton University with a focus on collective
+          problem-solving and collaborative processes.
+        </Translate>
+      </TeamProfileCardCol>
+      {/*<TeamProfileCardCol
+        name="Peter Sokol-Hessner"
+        githubUrl="https://github.com/psokolhessner"
+        twitterUrl="https://twitter.com/p1sh">
+        <Translate
+          id="team.profile.Peter Sokol-Hessner.body"
+          values={{
+            website: <WebsiteLink to="https://sokolhessnerlab.com/" />,
+          }}>
+          {
+            'Assistant Professor of Psychology at the University of Denver and the director of the Sokol-Hessner Lab. Learn more about his work on his lab\'s {website}'
+          }
+        </Translate>
+      </TeamProfileCardCol>*/}
+    </div>
+  );
+}
+
+export function IndustryAdvisorRow() {
+  return (
+    <div className="row">
+      <TeamProfileCardCol
+        name="Ayush Sood"
+        githubUrl="https://github.com/ayushsood"
+        linkedinUrl="https://www.linkedin.com/in/ayushsood/">
+        <Translate id="team.profile.Ayush Sood.body">
+          Product & Engineering Leader at Facebook
+        </Translate>
+      </TeamProfileCardCol>
+      <TeamProfileCardCol
+        name="Austin Chustz"
+        githubUrl="https://github.com/ATchustz"
+        linkedinUrl="https://www.linkedin.com/in/atchustz/"
+        photoUrl="https://media-exp1.licdn.com/dms/image/C4E03AQGTOVgYwASdUQ/profile-displayphoto-shrink_800_800/0/1517272810353?e=1623888000&v=beta&t=Xf9PFrxj15x1Vea5Z0vE-MfHysHpyiygbLpSNcgOEoA">
+        <Translate id="team.profile.Austin Chustz.body">
+          Full-Stack Software Developer at Fellow
+        </Translate>
+      </TeamProfileCardCol>
+      <TeamProfileCardCol
+        name="Aaron Rios"
+        linkedinUrl="https://www.linkedin.com/in/riosaaron/"
+        photoUrl="https://media-exp1.licdn.com/dms/image/C5603AQEEQAqzIhO7pg/profile-displayphoto-shrink_800_800/0/1534558999764?e=1623888000&v=beta&t=mQkK7CrHsoE3dL1bXYEwEopil5Fj-6HcO0_lK64BGNk">
+        <Translate id="team.profile.AJ Rios.body">
+          Data Scientist at Even
+        </Translate>
+      </TeamProfileCardCol>
+    </div>
+  );
+}


### PR DESCRIPTION
Creates a component directory in `/src` and the team card, which is adapted for both active team and industry advisor. Leaves people other than Ari commented out for now.