### PR TITLE
Remove nesting for getting started

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,25 +1,14 @@
 module.exports = {
   docs: [
     {
+      type: 'doc',
+      id: 'introduction',
+    },
+    {
       type: 'category',
-      label: 'Getting Started',
+      label: 'Tools Configuration',
       items: [
-        'introduction',
-        {
-          type: 'category',
-          label: 'Useful Concepts',
-          items: [
-            'concepts/command-line',
-            'concepts/text-editors',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Tools Configuration',
-          items: [
-            'configuration/github-accounts',
-          ],
-        },
+        'configuration/github-accounts',
       ],
     },
     {
@@ -34,6 +23,14 @@ module.exports = {
             'tutorials/git-goals',
           ],
         }
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Useful Concepts',
+      items: [
+        'concepts/command-line',
+        'concepts/text-editors',
       ],
     },
     {


### PR DESCRIPTION
Removes the "Getting Started" category in favor of taking one level of hierarchy away. Also moves useful concepts lower on sidebar.