### PR TITLE
fix: conditional rendering of volume, issue, page

### DIFF
--- a/src/components/Bibliography/index.js
+++ b/src/components/Bibliography/index.js
@@ -49,7 +49,7 @@ function Article({ authors, year, title, journal, volume, issue, page, DOI }) {
   return (
     <div className="row">
       <p className={styles.referenceItem}>
-        {authorList} ({year}). <b>{title}</b>. <i>{journal}, {volume}</i>({issue}), {page}. <Link to={"https://doi.org/".concat(DOI)}>https://doi.org/{DOI}</Link>
+        {authorList} ({year}). <b>{title}</b>. <i>{journal}{volume ? `, ${volume}` : ""}</i>{issue ? `(${issue})` : ""}{page ? `, ${page}` : ""}. <Link to={"https://doi.org/".concat(DOI)}>https://doi.org/{DOI}</Link>
       </p>
     </div>
   );


### PR DESCRIPTION
# Fix bibliography item rendering

## Description

Updates bibliography items to not render empty `volume`, `issue`, and `page` components.

Fixes #50

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
