### PR TITLE
fix: shorten `<a>` tag in bib items

### DIFF
--- a/src/components/Bibliography/index.js
+++ b/src/components/Bibliography/index.js
@@ -59,7 +59,7 @@ function Article({ authors, year, title, journal, volume, issue, page, DOI }) {
         </i>
         {issue ? `(${issue})` : ''}
         {page ? `, ${page}` : ''}.{' '}
-        <Link to={'https://doi.org/'.concat(DOI)}>https://doi.org/{DOI}</Link>
+        <Link to={'https://doi.org/'.concat(DOI)}>Link to article</Link>
       </p>
     </div>
   );


### PR DESCRIPTION
# Fix horizontal overflow for bibliography items

## Description

Changes DOI string label for links to article to `Link to article`, which previously caused horizontal overflow due to DOI links with `.` instead of `-` for line-wrapping.

Fixes #60 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
